### PR TITLE
File based call to `upsolver` CLI

### DIFF
--- a/executeworksheet.py
+++ b/executeworksheet.py
@@ -56,29 +56,29 @@ def main():
         else:
             print('No args found')
             sys.exit(2)
-    
+
     results = []
     for file in files:
-        sql_cmd = splitworksheet(file)
+        split_sql_files = splitworksheet(file)
         c = 1
-        for cmd in sql_cmd:
-            if c <= len(sql_cmd):
+        for idx, split_sql_file in enumerate(split_sql_files):
+            if c <= len(split_sql_files):
                 try:
-                    print('Executing {0}: {1}'.format(c, cmd))
+                    print('Executing {0}: {1}'.format((c + 1), split_sql_file))
                     res = subprocess.run(
-                        ['upsolver', '-c', '/config', 'execute', "-c", "{}".format(cmd)], capture_output=True, text=True, check=True
+                        ['upsolver', '-c', '/config', 'execute', "-f", "{}".format(split_sql_file)], capture_output=True, text=True, check=True
                     )
-                    results.append(QueryResults(file, c, cmd, res.stdout, res.stderr))
+                    results.append(QueryResults(file, c, split_sql_file, res.stdout, res.stderr))
                     c += 1
                 except subprocess.CalledProcessError as e:
                     print('Query execution failed: {}'.format(e.stderr))
-                    results.append(QueryResults(file, c, cmd, '', e.stderr))
+                    results.append(QueryResults(file, c, split_sql_file, '', e.stderr))
                     sys.exit(2)
 
         print('Finished executing {} \r\n'.format(os.path.basename(file)))
-    
+
     writeresults(results, local_path)
-        
+
 ## walk the input path
 ## return a list of .sql files (assumed to be worksheets)
 def getworksheets(input_path):
@@ -104,7 +104,7 @@ def getfilelist(items):
         name, file_ext = os.path.splitext(item)
         if file_ext.lower() in ['.sql']:
             worksheets.append(item)
-    
+
     worksheets.sort()
     return worksheets
 
@@ -112,7 +112,7 @@ def getfilelist(items):
 ## return a list of sql commands to execute
 def splitworksheet(path):
     print('Spliting SQL file in {}'.format(path))
-    cmds = []
+    files = []
     fd = open(path, 'r')
     ws_file = fd.read()
     fd.close()
@@ -122,14 +122,18 @@ def splitworksheet(path):
     s = re.sub(re.compile("--.*?\n") ,"" ,s)
 
     sql_commands = s.split(';')
-    
-    for s in sql_commands:
+
+    temp_dir = os.environ['RUNNER_TEMP']
+    for idx, s in enumerate(sql_commands):
         s = s.strip()
         if s:
             s = s + ';'
-            cmds.append(s)
+    tmp_filename = f"{temp_dir}/temp_{idx}.sql"
+    with open(tmp_filename, 'w', encoding='utf-8') as fd:
+        fd.write(s)
+    files.append(tmp_filename)
 
-    return cmds
+    return files
 
 ## write the worksheet execution results to a temp file
 def writeresults(data, local_path):

--- a/executeworksheet.py
+++ b/executeworksheet.py
@@ -136,8 +136,9 @@ def splitworksheet(path):
             s = s + ';'
 
             tmp_filename = f"{temp_dir}/temp_{idx}.usql"
-            with open(tmp_filename, 'w', encoding='utf-8') as fd:
+            with open(tmp_filename, 'w+', encoding='utf-8') as fd:
                 fd.write(s)
+                fd.flush()
             files.append(tmp_filename)
 
     return files

--- a/executeworksheet.py
+++ b/executeworksheet.py
@@ -132,10 +132,10 @@ def splitworksheet(path):
         if s:
             s = s + ';'
 
-        tmp_filename = f"{temp_dir}/temp_{idx}.usql"
-        with open(tmp_filename, 'w+', encoding='utf-8') as fd:
-            fd.write(s)
-        files.append(tmp_filename)
+            tmp_filename = f"{temp_dir}/temp_{idx}.usql"
+            with open(tmp_filename, 'w+', encoding='utf-8') as fd:
+                fd.write(s)
+            files.append(tmp_filename)
 
     return files
 

--- a/executeworksheet.py
+++ b/executeworksheet.py
@@ -123,8 +123,10 @@ def splitworksheet(path):
 
     sql_commands = s.split(';')
 
-    # temp_dir = os.environ['RUNNER_TEMP']
-    temp_dir = os.environ['TMPDIR']
+    temp_dir = f"{os.environ['RUNNER_TEMP']}/sqlake"
+    if not os.path.exists(temp_dir):
+        os.makedirs(temp_dir)
+
     for idx, s in enumerate(sql_commands):
         s = s.strip()
         if s:

--- a/executeworksheet.py
+++ b/executeworksheet.py
@@ -123,13 +123,14 @@ def splitworksheet(path):
 
     sql_commands = s.split(';')
 
-    temp_dir = os.environ['RUNNER_TEMP']
+    # temp_dir = os.environ['RUNNER_TEMP']
+    temp_dir = os.environ['TMPDIR']
     for idx, s in enumerate(sql_commands):
         s = s.strip()
         if s:
             s = s + ';'
     tmp_filename = f"{temp_dir}/temp_{idx}.sql"
-    with open(tmp_filename, 'w', encoding='utf-8') as fd:
+    with open(tmp_filename, 'w+', encoding='utf-8') as fd:
         fd.write(s)
     files.append(tmp_filename)
 

--- a/executeworksheet.py
+++ b/executeworksheet.py
@@ -137,6 +137,8 @@ def splitworksheet(path):
                 fd.write(s)
             files.append(tmp_filename)
 
+            print(f"Created {tmp_filename}: {s}")
+
     return files
 
 ## write the worksheet execution results to a temp file

--- a/executeworksheet.py
+++ b/executeworksheet.py
@@ -65,11 +65,8 @@ def main():
             if c <= len(split_sql_files):
                 try:
                     print('Executing {0}: {1}'.format(c, split_sql_file))
-                    with open(split_sql_file, 'r') as fd:
-                        exe_cmd = fd.read()
-                        print(f"!! Executing: {exe_cmd}")
                     res = subprocess.run(
-                        ['upsolver', 'execute', '-c', '/config', "-f", split_sql_file], capture_output=True, text=True, check=True
+                        ['upsolver', '--config', '/config', 'execute', "-f", split_sql_file], capture_output=True, text=True, check=True
                     )
                     results.append(QueryResults(file, c, split_sql_file, res.stdout, res.stderr))
                     c += 1

--- a/executeworksheet.py
+++ b/executeworksheet.py
@@ -65,8 +65,11 @@ def main():
             if c <= len(split_sql_files):
                 try:
                     print('Executing {0}: {1}'.format(c, split_sql_file))
+                    with open(split_sql_file, 'r') as fd:
+                        exe_cmd = fd.read()
+                        print(f"!! Executing: {exe_cmd}")
                     res = subprocess.run(
-                        ['upsolver', 'execute', '-c', '/config', "-f", "{}".format(split_sql_file)], capture_output=True, text=True, check=True
+                        ['upsolver', 'execute', '-c', '/config', "-f", split_sql_file], capture_output=True, text=True, check=True
                     )
                     results.append(QueryResults(file, c, split_sql_file, res.stdout, res.stderr))
                     c += 1

--- a/executeworksheet.py
+++ b/executeworksheet.py
@@ -64,7 +64,7 @@ def main():
         for idx, split_sql_file in enumerate(split_sql_files):
             if c <= len(split_sql_files):
                 try:
-                    print('Executing {0}: {1}'.format((c + 1), split_sql_file))
+                    print('Executing {0}: {1}'.format(c, split_sql_file))
                     res = subprocess.run(
                         ['upsolver', '-c', '/config', 'execute', "-f", "{}".format(split_sql_file)], capture_output=True, text=True, check=True
                     )
@@ -131,10 +131,11 @@ def splitworksheet(path):
         s = s.strip()
         if s:
             s = s + ';'
-    tmp_filename = f"{temp_dir}/temp_{idx}.sql"
-    with open(tmp_filename, 'w+', encoding='utf-8') as fd:
-        fd.write(s)
-    files.append(tmp_filename)
+
+        tmp_filename = f"{temp_dir}/temp_{idx}.usql"
+        with open(tmp_filename, 'w+', encoding='utf-8') as fd:
+            fd.write(s)
+        files.append(tmp_filename)
 
     return files
 

--- a/executeworksheet.py
+++ b/executeworksheet.py
@@ -66,7 +66,7 @@ def main():
                 try:
                     print('Executing {0}: {1}'.format(c, split_sql_file))
                     res = subprocess.run(
-                        ['upsolver', '-c', '/config', 'execute', "-f", "{}".format(split_sql_file)], capture_output=True, text=True, check=True
+                        ['upsolver', 'execute', '-c', '/config', "-f", "{}".format(split_sql_file)], capture_output=True, text=True, check=True
                     )
                     results.append(QueryResults(file, c, split_sql_file, res.stdout, res.stderr))
                     c += 1
@@ -133,11 +133,9 @@ def splitworksheet(path):
             s = s + ';'
 
             tmp_filename = f"{temp_dir}/temp_{idx}.usql"
-            with open(tmp_filename, 'w+', encoding='utf-8') as fd:
+            with open(tmp_filename, 'w', encoding='utf-8') as fd:
                 fd.write(s)
             files.append(tmp_filename)
-
-            print(f"Created {tmp_filename}: {s}")
 
     return files
 


### PR DESCRIPTION
Instead of passing the SQL in as a string to `upsolver execute` using the `-c` flag, use the `-f` flag by parsing the single file into several temp files each with an individual SQL statement and execute each one individually via `upsolver execute -f <temp_file>.usql`